### PR TITLE
[iOS] set up detailView UI

### DIFF
--- a/iOS/SideDish/SideDish.xcodeproj/project.pbxproj
+++ b/iOS/SideDish/SideDish.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		A59ACBDD2453F40700359A0A /* ImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59ACBDC2453F40700359A0A /* ImageUseCase.swift */; };
 		A5A4DFE82451467700C734F1 /* SideDishUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A4DFE72451467700C734F1 /* SideDishUseCase.swift */; };
 		A5AB37B52458510A0015A192 /* DetailDish.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AB37B42458510A0015A192 /* DetailDish.swift */; };
+		A5AB37B7245851E60015A192 /* DetailInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AB37B6245851E60015A192 /* DetailInfoUseCase.swift */; };
 		A5BD927E244DCAE600D6442F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BD927D244DCAE600D6442F /* AppDelegate.swift */; };
 		A5BD9282244DCAE600D6442F /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BD9281244DCAE600D6442F /* LoginViewController.swift */; };
 		A5BD9285244DCAE600D6442F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A5BD9283244DCAE600D6442F /* Main.storyboard */; };
@@ -56,6 +57,7 @@
 		A59ACBDC2453F40700359A0A /* ImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUseCase.swift; sourceTree = "<group>"; };
 		A5A4DFE72451467700C734F1 /* SideDishUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideDishUseCase.swift; sourceTree = "<group>"; };
 		A5AB37B42458510A0015A192 /* DetailDish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailDish.swift; sourceTree = "<group>"; };
+		A5AB37B6245851E60015A192 /* DetailInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailInfoUseCase.swift; sourceTree = "<group>"; };
 		A5BD927A244DCAE500D6442F /* SideDish.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SideDish.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5BD927D244DCAE600D6442F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5BD9281244DCAE600D6442F /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 			children = (
 				A5A4DFE72451467700C734F1 /* SideDishUseCase.swift */,
 				A59ACBDC2453F40700359A0A /* ImageUseCase.swift */,
+				A5AB37B6245851E60015A192 /* DetailInfoUseCase.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -364,6 +367,7 @@
 				A5A4DFE82451467700C734F1 /* SideDishUseCase.swift in Sources */,
 				A516CF18245060C100F96635 /* NetworkManager.swift in Sources */,
 				A516CF4224507C8D00F96635 /* SideDishManager.swift in Sources */,
+				A5AB37B7245851E60015A192 /* DetailInfoUseCase.swift in Sources */,
 				A5BD927E244DCAE600D6442F /* AppDelegate.swift in Sources */,
 				A5AB37B52458510A0015A192 /* DetailDish.swift in Sources */,
 				A52A3F07244ECFEC005795A4 /* MainMenuTableViewCell.swift in Sources */,

--- a/iOS/SideDish/SideDish.xcodeproj/project.pbxproj
+++ b/iOS/SideDish/SideDish.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		A58FAEDF2452DF1200C9EDA3 /* MainMenuHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A58FAEDE2452DF1200C9EDA3 /* MainMenuHeader.swift */; };
 		A59ACBDD2453F40700359A0A /* ImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59ACBDC2453F40700359A0A /* ImageUseCase.swift */; };
 		A5A4DFE82451467700C734F1 /* SideDishUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A4DFE72451467700C734F1 /* SideDishUseCase.swift */; };
+		A5AB37B52458510A0015A192 /* DetailDish.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AB37B42458510A0015A192 /* DetailDish.swift */; };
 		A5BD927E244DCAE600D6442F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BD927D244DCAE600D6442F /* AppDelegate.swift */; };
 		A5BD9282244DCAE600D6442F /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BD9281244DCAE600D6442F /* LoginViewController.swift */; };
 		A5BD9285244DCAE600D6442F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A5BD9283244DCAE600D6442F /* Main.storyboard */; };
@@ -54,6 +55,7 @@
 		A58FAEDE2452DF1200C9EDA3 /* MainMenuHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenuHeader.swift; sourceTree = "<group>"; };
 		A59ACBDC2453F40700359A0A /* ImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUseCase.swift; sourceTree = "<group>"; };
 		A5A4DFE72451467700C734F1 /* SideDishUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideDishUseCase.swift; sourceTree = "<group>"; };
+		A5AB37B42458510A0015A192 /* DetailDish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailDish.swift; sourceTree = "<group>"; };
 		A5BD927A244DCAE500D6442F /* SideDish.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SideDish.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5BD927D244DCAE600D6442F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5BD9281244DCAE600D6442F /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 				A516CF19245061E000F96635 /* SideDish.swift */,
 				A516CF4124507C8D00F96635 /* SideDishManager.swift */,
 				A5BF0E2724581CBF00222FF3 /* UIColorExtension.swift */,
+				A5AB37B42458510A0015A192 /* DetailDish.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -362,6 +365,7 @@
 				A516CF18245060C100F96635 /* NetworkManager.swift in Sources */,
 				A516CF4224507C8D00F96635 /* SideDishManager.swift in Sources */,
 				A5BD927E244DCAE600D6442F /* AppDelegate.swift in Sources */,
+				A5AB37B52458510A0015A192 /* DetailDish.swift in Sources */,
 				A52A3F07244ECFEC005795A4 /* MainMenuTableViewCell.swift in Sources */,
 				A516CF1A245061E000F96635 /* SideDish.swift in Sources */,
 				A508FC37244EDBDE009AC902 /* PaddingLabel.swift in Sources */,

--- a/iOS/SideDish/SideDish.xcodeproj/project.pbxproj
+++ b/iOS/SideDish/SideDish.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		A5BD9287244DCAE900D6442F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A5BD9286244DCAE900D6442F /* Assets.xcassets */; };
 		A5BD928A244DCAE900D6442F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A5BD9288244DCAE900D6442F /* LaunchScreen.storyboard */; };
 		A5BD9295244DCAE900D6442F /* SideDishTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BD9294244DCAE900D6442F /* SideDishTests.swift */; };
+		A5BF0E2824581CBF00222FF3 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BF0E2724581CBF00222FF3 /* UIColorExtension.swift */; };
 		A5E4F581245176E1007AAA3D /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E4F580245176E1007AAA3D /* DetailViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -63,6 +64,7 @@
 		A5BD9290244DCAE900D6442F /* SideDishTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SideDishTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5BD9294244DCAE900D6442F /* SideDishTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideDishTests.swift; sourceTree = "<group>"; };
 		A5BD9296244DCAE900D6442F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A5BF0E2724581CBF00222FF3 /* UIColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		A5E4F580245176E1007AAA3D /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -100,6 +102,7 @@
 				A516CF17245060C100F96635 /* NetworkManager.swift */,
 				A516CF19245061E000F96635 /* SideDish.swift */,
 				A516CF4124507C8D00F96635 /* SideDishManager.swift */,
+				A5BF0E2724581CBF00222FF3 /* UIColorExtension.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -349,6 +352,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A516CF3D2450684500F96635 /* MainMenuViewDataSource.swift in Sources */,
+				A5BF0E2824581CBF00222FF3 /* UIColorExtension.swift in Sources */,
 				A58FAEDF2452DF1200C9EDA3 /* MainMenuHeader.swift in Sources */,
 				A53BA05F244EA6DE0023D27D /* MainMenuViewController.swift in Sources */,
 				A5E4F581245176E1007AAA3D /* DetailViewController.swift in Sources */,

--- a/iOS/SideDish/SideDish/Controller/DetailInfoUseCase.swift
+++ b/iOS/SideDish/SideDish/Controller/DetailInfoUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  DetailInfoUseCase.swift
+//  SideDish
+//
+//  Created by 신한섭 on 2020/04/28.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+import Foundation
+
+struct DetailInfoUseCase {
+    static func loadMainDish(with manager: NetworkManager, id: Int , failureHandler: @escaping (NetworkManager.NetworkError) -> () = {_ in}, completed: @escaping(DishInfo, Int) -> ()) {
+        manager.getDetailDish(id: id) {
+            switch $0 {
+            case .failure(let error):
+                failureHandler(error)
+            case .success(let data):
+                do {
+                    let model = try JSONDecoder().decode(DetailDish.self, from: data)
+                    completed(model.body, 0)
+                } catch {
+                    failureHandler(.DecodeError)
+                }
+            }
+        }
+    }
+}

--- a/iOS/SideDish/SideDish/Controller/DetailInfoUseCase.swift
+++ b/iOS/SideDish/SideDish/Controller/DetailInfoUseCase.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct DetailInfoUseCase {
-    static func loadMainDish(with manager: NetworkManager, id: Int , failureHandler: @escaping (NetworkManager.NetworkError) -> () = {_ in}, completed: @escaping(DishInfo, Int) -> ()) {
+    static func loadDetailDish(with manager: NetworkManager, id: Int , failureHandler: @escaping (NetworkManager.NetworkError) -> () = {_ in}, completed: @escaping(DishInfo) -> ()) {
         manager.getDetailDish(id: id) {
             switch $0 {
             case .failure(let error):
@@ -17,7 +17,7 @@ struct DetailInfoUseCase {
             case .success(let data):
                 do {
                     let model = try JSONDecoder().decode(DetailDish.self, from: data)
-                    completed(model.body, 0)
+                    completed(model.body)
                 } catch {
                     failureHandler(.DecodeError)
                 }

--- a/iOS/SideDish/SideDish/Controller/ImageUseCase.swift
+++ b/iOS/SideDish/SideDish/Controller/ImageUseCase.swift
@@ -9,14 +9,32 @@
 import Foundation
 
 struct ImageUseCase {
-    
-    static func loadImage(with manager: NetworkManager, from: URL, failureHandler: @escaping (NetworkManager.NetworkError) -> (), completed: @escaping(URL) -> ()) {
-        manager.downloadResource(from: from) {
-            switch $0 {
-            case .failure(let error):
-                failureHandler(error)
-            case .success(let url):
-                completed(url)
+    static let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+    static func loadImage(with manager: NetworkManager, from: URL, failureHandler: @escaping (NetworkManager.NetworkError) -> (), completed: @escaping(Data) -> ()) {
+        
+        let imageURL = cachesDirectory.appendingPathComponent(from.lastPathComponent)
+        
+        if FileManager.default.fileExists(atPath: imageURL.path) {
+            do {
+                let data = try Data(contentsOf: imageURL)
+                completed(data)
+            } catch {
+                failureHandler(.DecodeError)
+            }
+        } else {
+            manager.downloadResource(from: from) {
+                switch $0 {
+                case .failure(let error):
+                    failureHandler(error)
+                case .success(let url):
+                    do {
+                        let data = try Data(contentsOf: url)
+                        completed(data)
+                        try? FileManager.default.moveItem(at: url, to: imageURL)
+                    } catch {
+                        failureHandler(.DecodeError)
+                    }
+                }
             }
         }
     }

--- a/iOS/SideDish/SideDish/Controller/ImageUseCase.swift
+++ b/iOS/SideDish/SideDish/Controller/ImageUseCase.swift
@@ -15,27 +15,26 @@ struct ImageUseCase {
         let imageURL = cachesDirectory.appendingPathComponent(from.lastPathComponent)
         
         if FileManager.default.fileExists(atPath: imageURL.path) {
-            do {
-                let data = try Data(contentsOf: imageURL)
-                completed(data)
-            } catch {
-                failureHandler(.DecodeError)
-            }
+            handleData(from: imageURL, failureHandler: failureHandler, completed: completed)
         } else {
             manager.downloadResource(from: from) {
                 switch $0 {
                 case .failure(let error):
                     failureHandler(error)
                 case .success(let url):
-                    do {
-                        let data = try Data(contentsOf: url)
-                        completed(data)
-                        try? FileManager.default.moveItem(at: url, to: imageURL)
-                    } catch {
-                        failureHandler(.DecodeError)
-                    }
+                    handleData(from: url, failureHandler: failureHandler, completed: completed)
+                    try? FileManager.default.moveItem(at: url, to: imageURL)
                 }
             }
+        }
+    }
+    
+    private static func handleData(from url: URL, failureHandler: @escaping (NetworkManager.NetworkError) -> (), completed: @escaping(Data) -> ()) {
+        do {
+            let data = try Data(contentsOf: url)
+            completed(data)
+        } catch {
+            failureHandler(.DecodeError)
         }
     }
 }

--- a/iOS/SideDish/SideDish/Controller/ImageUseCase.swift
+++ b/iOS/SideDish/SideDish/Controller/ImageUseCase.swift
@@ -11,7 +11,6 @@ import Foundation
 struct ImageUseCase {
     static let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
     static func loadImage(with manager: NetworkManager, from: URL, failureHandler: @escaping (NetworkManager.NetworkError) -> (), completed: @escaping(Data) -> ()) {
-        
         let imageURL = cachesDirectory.appendingPathComponent(from.lastPathComponent)
         
         if FileManager.default.fileExists(atPath: imageURL.path) {

--- a/iOS/SideDish/SideDish/DetailView/DetailViewController.swift
+++ b/iOS/SideDish/SideDish/DetailView/DetailViewController.swift
@@ -12,6 +12,7 @@ class DetailViewController: UIViewController {
     
     @IBOutlet weak var thumbnailScrollView: UIScrollView!
     @IBOutlet weak var thumbnailStackView: UIStackView!
+    @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var descriptionLabel: UILabel!
     @IBOutlet weak var mileageLabel: UILabel!
     @IBOutlet weak var deliveryFeeLabel: UILabel!
@@ -20,6 +21,7 @@ class DetailViewController: UIViewController {
     @IBOutlet weak var contentScrollView: UIScrollView!
     
     var id: Int!
+    var titleText: String!
     private var model: DishInfo? {
         didSet {
             DispatchQueue.main.async {
@@ -51,6 +53,7 @@ class DetailViewController: UIViewController {
     
     private func setupUI() {
         guard let model = model else {return}
+        titleLabel.text = titleText
         descriptionLabel.text = model.product_description
         mileageLabel.text = model.point
         deliveryFeeLabel.text = model.delivery_fee

--- a/iOS/SideDish/SideDish/DetailView/DetailViewController.swift
+++ b/iOS/SideDish/SideDish/DetailView/DetailViewController.swift
@@ -80,9 +80,23 @@ class DetailViewController: UIViewController {
         
         for from in model.detail_section {
             let imageView = UIImageView()
+            imageView.contentMode = .scaleAspectFill
             detailImageViews.append(imageView)
             detailImageStackView.addArrangedSubview(imageView)
             imageView.widthAnchor.constraint(equalTo: contentScrollView.frameLayoutGuide.widthAnchor, multiplier: 1).isActive = true
+            
+            guard let url = URL(string: from) else {
+                errorHandling(error: .InvalidURL)
+                return
+            }
+            
+            ImageUseCase.loadImage(with: NetworkManager(), from: url, failureHandler: {self.errorHandling(error:$0)}) {
+                let image = UIImage(data: $0)
+                DispatchQueue.main.async {
+                    imageView.image = image
+                    imageView.heightAnchor.constraint(equalToConstant: imageView.frame.width * (image?.size.height ?? 1) / (image?.size.width ?? 1)).isActive = true
+                }
+            }
         }
     }
     

--- a/iOS/SideDish/SideDish/DetailView/DetailViewController.swift
+++ b/iOS/SideDish/SideDish/DetailView/DetailViewController.swift
@@ -12,6 +12,10 @@ class DetailViewController: UIViewController {
     
     var id: Int!
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.isNavigationBarHidden = false

--- a/iOS/SideDish/SideDish/DetailView/DetailViewController.swift
+++ b/iOS/SideDish/SideDish/DetailView/DetailViewController.swift
@@ -10,10 +10,30 @@ import UIKit
 import Toaster
 class DetailViewController: UIViewController {
     
+    @IBOutlet weak var thumbnailScrollView: UIScrollView!
+    @IBOutlet weak var thumbnailStackView: UIStackView!
+    @IBOutlet weak var descriptionLabel: UILabel!
+    @IBOutlet weak var mileageLabel: UILabel!
+    @IBOutlet weak var deliveryFeeLabel: UILabel!
+    @IBOutlet weak var deliveryInfoLabel: UILabel!
+    @IBOutlet weak var detailImageStackView: UIStackView!
+    @IBOutlet weak var contentScrollView: UIScrollView!
+    
+    private var thumnailImageViews = [UIImageView]()
+    private var detailImageViews = [UIImageView]()
+    
     var id: Int!
+    private var model: DishInfo? {
+        didSet {
+            DispatchQueue.main.async {
+                self.setupUI()
+            }
+        }
+    }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        configureUseCase(id: id)
     }
     
     override func viewDidLoad() {
@@ -25,4 +45,61 @@ class DetailViewController: UIViewController {
         super.viewWillDisappear(animated)
         navigationController?.isNavigationBarHidden = true
     }
+    
+    private func configureUseCase(id: Int) {
+        DetailInfoUseCase.loadDetailDish(with: NetworkManager(), id: id, failureHandler: {self.errorHandling(error: $0)}) {
+            self.model = $0
+        }
+    }
+    
+    private func setupUI() {
+        guard let model = model else {return}
+        descriptionLabel.text = model.product_description
+        mileageLabel.text = model.point
+        deliveryFeeLabel.text = model.delivery_fee
+        deliveryInfoLabel.text = model.delivery_info
+        
+        for from in model.thumb_images {
+            let imageView = UIImageView()
+            thumbnailStackView.addArrangedSubview(imageView)
+            imageView.widthAnchor.constraint(equalTo: thumbnailScrollView.frameLayoutGuide.widthAnchor, multiplier: 1).isActive = true
+            imageView.contentMode = .scaleAspectFill
+            
+            guard let url = URL(string: from) else {
+                errorHandling(error: .InvalidURL)
+                return
+            }
+            
+            ImageUseCase.loadImage(with: NetworkManager(), from: url, failureHandler: {self.errorHandling(error:$0)}) {
+                let image = UIImage(data: $0)
+                DispatchQueue.main.async {
+                    imageView.image = image
+                }
+            }
+        }
+        
+        for from in model.detail_section {
+            let imageView = UIImageView()
+            detailImageViews.append(imageView)
+            detailImageStackView.addArrangedSubview(imageView)
+            imageView.widthAnchor.constraint(equalTo: contentScrollView.frameLayoutGuide.widthAnchor, multiplier: 1).isActive = true
+        }
+    }
+    
+    private func alertError(message: String) {
+        DispatchQueue.main.async {
+            let alert = UIAlertController(title: "문제가 생겼어요", message: message, preferredStyle: .alert)
+            let ok = UIAlertAction(title: "넵...", style: .default)
+            alert.addAction(ok)
+            self.present(alert, animated: true)
+        }
+    }
+    
+    private func errorHandling(error: NetworkManager.NetworkError) {
+        alertError(message: error.message())
+    }
+}
+
+extension Notification.Name {
+    static let p = Notification.Name("p")
 }

--- a/iOS/SideDish/SideDish/DetailView/DetailViewController.swift
+++ b/iOS/SideDish/SideDish/DetailView/DetailViewController.swift
@@ -19,9 +19,6 @@ class DetailViewController: UIViewController {
     @IBOutlet weak var detailImageStackView: UIStackView!
     @IBOutlet weak var contentScrollView: UIScrollView!
     
-    private var thumnailImageViews = [UIImageView]()
-    private var detailImageViews = [UIImageView]()
-    
     var id: Int!
     private var model: DishInfo? {
         didSet {
@@ -61,9 +58,7 @@ class DetailViewController: UIViewController {
         
         for from in model.thumb_images {
             let imageView = UIImageView()
-            thumbnailStackView.addArrangedSubview(imageView)
-            imageView.widthAnchor.constraint(equalTo: thumbnailScrollView.frameLayoutGuide.widthAnchor, multiplier: 1).isActive = true
-            imageView.contentMode = .scaleAspectFill
+            InsertImageView(into: thumbnailStackView, imageView: imageView, constraintAnchor: thumbnailScrollView)
             
             guard let url = URL(string: from) else {
                 errorHandling(error: .InvalidURL)
@@ -80,10 +75,7 @@ class DetailViewController: UIViewController {
         
         for from in model.detail_section {
             let imageView = UIImageView()
-            imageView.contentMode = .scaleAspectFill
-            detailImageViews.append(imageView)
-            detailImageStackView.addArrangedSubview(imageView)
-            imageView.widthAnchor.constraint(equalTo: contentScrollView.frameLayoutGuide.widthAnchor, multiplier: 1).isActive = true
+            InsertImageView(into: detailImageStackView, imageView: imageView, constraintAnchor: contentScrollView)
             
             guard let url = URL(string: from) else {
                 errorHandling(error: .InvalidURL)
@@ -100,6 +92,12 @@ class DetailViewController: UIViewController {
         }
     }
     
+    private func InsertImageView(into stackView: UIStackView, imageView: UIImageView, constraintAnchor: UIScrollView) {
+        imageView.contentMode = .scaleAspectFill
+        stackView.addArrangedSubview(imageView)
+        imageView.widthAnchor.constraint(equalTo: constraintAnchor.frameLayoutGuide.widthAnchor, multiplier: 1).isActive = true
+    }
+    
     private func alertError(message: String) {
         DispatchQueue.main.async {
             let alert = UIAlertController(title: "문제가 생겼어요", message: message, preferredStyle: .alert)
@@ -112,8 +110,4 @@ class DetailViewController: UIViewController {
     private func errorHandling(error: NetworkManager.NetworkError) {
         alertError(message: error.message())
     }
-}
-
-extension Notification.Name {
-    static let p = Notification.Name("p")
 }

--- a/iOS/SideDish/SideDish/LoginView/LoginViewController.swift
+++ b/iOS/SideDish/SideDish/LoginView/LoginViewController.swift
@@ -11,9 +11,6 @@ import UIKit
 class LoginViewController: UIViewController {
     
     @IBAction func loginButtonPushed(_ sender: UIButton) {
-        dismiss(animated: true)
-        NotificationCenter.default.post(name: .LoginSuccess,
-                                        object: nil)
     }
     
     override func viewDidLoad() {

--- a/iOS/SideDish/SideDish/MainMenuView/MainMenuTableViewCell.swift
+++ b/iOS/SideDish/SideDish/MainMenuView/MainMenuTableViewCell.swift
@@ -57,16 +57,16 @@ class MainMenuTableViewCell: UITableViewCell {
         specialPriceLabel.text = special
     }
     
-    private func setEventStackView(badges: [String]?) {
+    private func setEventStackView(badges: [Badge]?) {
         guard let badges = badges, badges.count > 0 else {return}
         
         badges.forEach {
             let label = PaddingLabel()
-            label.text = $0
+            label.text = $0.name
             label.font = UIFont.systemFont(ofSize: 12)
             label.textColor = .white
             label.textAlignment = .center
-            label.backgroundColor = UIColor(named: "SpecialPriceColor")
+            label.backgroundColor = UIColor(hex: $0.color)
             eventStackView.addArrangedSubview(label)
         }
     }

--- a/iOS/SideDish/SideDish/MainMenuView/MainMenuViewController.swift
+++ b/iOS/SideDish/SideDish/MainMenuView/MainMenuViewController.swift
@@ -18,7 +18,7 @@ class MainMenuViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.interactivePopGestureRecognizer?.delegate = nil
-        popUpLoginView()
+        configureUseCase()
         setupTableView()
         setupObserver()
         setupDataSource()
@@ -37,19 +37,10 @@ class MainMenuViewController: UIViewController {
         }
     }
     
-    private func popUpLoginView() {
-        guard let loginViewController = self.storyboard?.instantiateViewController(withIdentifier: "LoginViewController") as? LoginViewController else {return}
-        present(loginViewController, animated: true)
-    }
-    
     private func setupObserver() {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(reloadSection(_:)),
                                                name: .ModelInserted,
-                                               object: nil)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(loadData),
-                                               name: .LoginSuccess,
                                                object: nil)
     }
     
@@ -95,10 +86,6 @@ class MainMenuViewController: UIViewController {
     @objc func reloadSection(_ notification: Notification) {
         guard let index = notification.userInfo?["index"] as? Int else {return}
         mainMenuTableView.reloadSections(IndexSet(index...index), with: .automatic)
-    }
-    
-    @objc func loadData() {
-        configureUseCase()
     }
 }
 

--- a/iOS/SideDish/SideDish/MainMenuView/MainMenuViewController.swift
+++ b/iOS/SideDish/SideDish/MainMenuView/MainMenuViewController.swift
@@ -109,6 +109,7 @@ extension MainMenuViewController: UITableViewDelegate {
         let dish = mainMenuDataSource.sideDishManager.sideDish(indexPath: indexPath)
         guard let detailViewController = self.storyboard?.instantiateViewController(withIdentifier: "DetailViewController") as? DetailViewController else {return}
         detailViewController.id = dish.id
+        detailViewController.titleText = dish.title
         let text = "타이틀 메뉴 : \(dish.title)\n\(dish.specialPrice)"
         Toast(text: text).show()
         self.navigationController?.pushViewController(detailViewController, animated: true)

--- a/iOS/SideDish/SideDish/MainMenuView/MainMenuViewController.swift
+++ b/iOS/SideDish/SideDish/MainMenuView/MainMenuViewController.swift
@@ -15,8 +15,6 @@ class MainMenuViewController: UIViewController {
     
     private var mainMenuDataSource =  MainMenuViewDataSource()
     
-    let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.interactivePopGestureRecognizer?.delegate = nil
@@ -32,32 +30,11 @@ class MainMenuViewController: UIViewController {
                 self.errorHandling(error: .InvalidURL)
                 return
             }
-            let imageURL = self.localFilePath(for: requestURL)
             
-            if FileManager.default.fileExists(atPath: imageURL.path) {
-                self.setImage(into: cell, from: imageURL)
-            } else {
-                ImageUseCase.loadImage(with: NetworkManager(), from: requestURL, failureHandler: {self.errorHandling(error: $0)}) { resultURL in
-                    self.setImage(into: cell, from: resultURL)
-                    try? FileManager.default.moveItem(at: resultURL, to: imageURL)
-                }
+            ImageUseCase.loadImage(with: NetworkManager(), from: requestURL, failureHandler: {self.errorHandling(error: $0)}) {
+                cell.setImageFromData(data: $0)
             }
         }
-    }
-    
-    private func setImage(into cell: MainMenuTableViewCell, from url: URL) {
-        do {
-            let data = try Data(contentsOf: url)
-            DispatchQueue.main.async {
-                cell.setImageFromData(data: data)
-            }
-        } catch {
-            self.errorHandling(error: .DecodeError)
-        }
-    }
-    
-    private func localFilePath(for url: URL) -> URL {
-        return cachesDirectory.appendingPathComponent(url.lastPathComponent)
     }
     
     private func popUpLoginView() {

--- a/iOS/SideDish/SideDish/Model/DetailDish.swift
+++ b/iOS/SideDish/SideDish/Model/DetailDish.swift
@@ -6,8 +6,20 @@
 //  Copyright © 2020 신한섭. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
-class DetailDish: NSObject {
+struct DetailDish: Codable {
+    var body: DishInfo
+}
 
+struct DishInfo: Codable {
+    var id: Int
+    var top_image: String
+    var product_description: String
+    var point: String
+    var delivery_info: String
+    var s_price: String?
+    var n_price: String?
+    var detail_section: [String]
+    var thumb_images: [String]
 }

--- a/iOS/SideDish/SideDish/Model/DetailDish.swift
+++ b/iOS/SideDish/SideDish/Model/DetailDish.swift
@@ -18,6 +18,7 @@ struct DishInfo: Codable {
     var product_description: String
     var point: String
     var delivery_info: String
+    var delivery_fee: String
     var s_price: String?
     var n_price: String?
     var detail_section: [String]

--- a/iOS/SideDish/SideDish/Model/DetailDish.swift
+++ b/iOS/SideDish/SideDish/Model/DetailDish.swift
@@ -1,0 +1,13 @@
+//
+//  DetailDish.swift
+//  SideDish
+//
+//  Created by 신한섭 on 2020/04/28.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+import UIKit
+
+class DetailDish: NSObject {
+
+}

--- a/iOS/SideDish/SideDish/Model/NetworkManager.swift
+++ b/iOS/SideDish/SideDish/Model/NetworkManager.swift
@@ -19,7 +19,7 @@ typealias downloadHandler = (Result<URL, NetworkManager.NetworkError>) -> Void
 class NetworkManager: NetworkManageable {
     
     enum EndPoints {
-        static let serverURL = "http://15.165.138.17:8080/develop/baminchan/"
+        static let serverURL = "http://13.125.179.178:8080/develop/baminchan/"
         static let main = "main"
         static let soup = "soup"
         static let side = "side"

--- a/iOS/SideDish/SideDish/Model/NetworkManager.swift
+++ b/iOS/SideDish/SideDish/Model/NetworkManager.swift
@@ -23,6 +23,7 @@ class NetworkManager: NetworkManageable {
         static let main = "main"
         static let soup = "soup"
         static let side = "side"
+        static let detail = "detail"
     }
     
     enum NetworkError: Error {
@@ -118,6 +119,10 @@ class NetworkManager: NetworkManageable {
     
     func getSideDish(handler: @escaping dataHandler) {
         getResource(from: EndPoints.serverURL + EndPoints.side, method: .get, headers: nil, handler: handler)
+    }
+    
+    func getDetailDish(id: Int, handler: @escaping dataHandler) {
+        getResource(from: EndPoints.serverURL + EndPoints.detail + "/\(id)", method: .get, headers: nil, handler: handler)
     }
     
     func getImageURL(from: URL, handler: @escaping downloadHandler) {

--- a/iOS/SideDish/SideDish/Model/SideDish.swift
+++ b/iOS/SideDish/SideDish/Model/SideDish.swift
@@ -10,9 +10,10 @@ import Foundation
 
 struct SideDish: Codable {
     var sideDishes: [SideDishInfo]
-    
+    var menuId: Int
     enum CodingKeys: String, CodingKey {
         case sideDishes = "body"
+        case menuId
     }
 }
 
@@ -23,7 +24,7 @@ struct SideDishInfo: Codable {
     var description: String
     var originalPrice: String?
     var specialPrice: String
-    var badges: [String]?
+    var badges: [Badge]?
     
     enum CodingKeys: String, CodingKey {
         case id
@@ -36,5 +37,9 @@ struct SideDishInfo: Codable {
     }
 }
 
+struct Badge: Codable {
+    var color: String
+    var name: String
+}
 
 

--- a/iOS/SideDish/SideDish/Model/UIColorExtension.swift
+++ b/iOS/SideDish/SideDish/Model/UIColorExtension.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension UIColor {
     public convenience init?(hex: String) {
-        let r, g, b, a: CGFloat
+        let r, g, b: CGFloat
 
         if hex.hasPrefix("#") {
             let start = hex.index(hex.startIndex, offsetBy: 1)

--- a/iOS/SideDish/SideDish/Model/UIColorExtension.swift
+++ b/iOS/SideDish/SideDish/Model/UIColorExtension.swift
@@ -1,0 +1,37 @@
+//
+//  UIColorExtension.swift
+//  SideDish
+//
+//  Created by 신한섭 on 2020/04/28.
+//  Copyright © 2020 신한섭. All rights reserved.
+//
+
+import UIKit
+
+extension UIColor {
+    public convenience init?(hex: String) {
+        let r, g, b, a: CGFloat
+
+        if hex.hasPrefix("#") {
+            let start = hex.index(hex.startIndex, offsetBy: 1)
+            let hexColor = String(hex[start...])
+
+            if hexColor.count == 6 {
+                let scanner = Scanner(string: hexColor)
+                var hexNumber: UInt64 = 0
+
+                if scanner.scanHexInt64(&hexNumber) {
+                    r = CGFloat((hexNumber & 0xff0000) >> 16) / 255
+                    g = CGFloat((hexNumber & 0x00ff00) >> 8) / 255
+                    b = CGFloat((hexNumber & 0x0000ff)) / 255
+
+                    self.init(red: r, green: g, blue: b, alpha: 1)
+                    return
+                }
+            }
+        }
+
+        return nil
+    }
+}
+

--- a/iOS/SideDish/SideDish/Resource/Assets.xcassets/divisionColor.colorset/Contents.json
+++ b/iOS/SideDish/SideDish/Resource/Assets.xcassets/divisionColor.colorset/Contents.json
@@ -1,0 +1,51 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "platform" : "ios",
+        "reference" : "darkTextColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.996",
+          "green" : "1.000",
+          "red" : "0.996"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
+++ b/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
@@ -343,7 +343,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="n8N-sQ-S2A" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2105" y="126"/>
+            <point key="canvasLocation" x="1990" y="115"/>
         </scene>
         <!--Detail View Controller-->
         <scene sceneID="ICD-Kh-mga">
@@ -357,13 +357,13 @@
                                 <rect key="frame" x="0.0" y="44" width="375" height="660.66666666666663"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="oHd-zl-Tmv" userLabel="Content Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="502.33333333333331"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="568.33333333333337"/>
                                         <subviews>
                                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pEl-4t-h4D" userLabel="Horizontal Scroll View">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="264.33333333333331"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="330.33333333333331"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="ZVb-d1-dud">
-                                                        <rect key="frame" x="0.0" y="0.0" width="0.0" height="264.33333333333331"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="0.0" height="330.33333333333331"/>
                                                         <subviews>
                                                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FVe-LJ-ivg">
                                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="264.33333333333331"/>
@@ -384,7 +384,7 @@
                                                 <viewLayoutGuide key="frameLayoutGuide" id="73M-un-vdE"/>
                                             </scrollView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="J91-gK-g6H" userLabel="Title Stack View">
-                                                <rect key="frame" x="18.666666666666657" y="274.33333333333331" width="337.66666666666674" height="52.666666666666686"/>
+                                                <rect key="frame" x="18.666666666666657" y="340.33333333333331" width="337.66666666666674" height="52.666666666666686"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="[모이세] 육개장 1팩(600g)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4fG-oy-fpg" userLabel="Title Label">
                                                         <rect key="frame" x="0.0" y="0.0" width="337.66666666666669" height="28"/>
@@ -401,17 +401,17 @@
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GzZ-zz-gCi" userLabel="DivisionView">
-                                                <rect key="frame" x="9.3333333333333428" y="337" width="356.33333333333326" height="3"/>
+                                                <rect key="frame" x="9.3333333333333428" y="403" width="356.33333333333326" height="3"/>
                                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="3" id="KAf-qZ-pdK"/>
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="le8-v4-LtK" userLabel="Info Stack View">
-                                                <rect key="frame" x="18.666666666666657" y="350" width="337.66666666666674" height="105.66666666666669"/>
+                                                <rect key="frame" x="18.666666666666657" y="416" width="337.66666666666674" height="106"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="4pk-3C-dO0">
-                                                        <rect key="frame" x="0.0" y="0.0" width="67.666666666666671" height="105.66666666666667"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="67.666666666666671" height="106"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가격" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DNG-bo-bmG">
                                                                 <rect key="frame" x="0.0" y="0.0" width="67.666666666666671" height="26.666666666666668"/>
@@ -432,7 +432,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="배송정보" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tue-fG-Jdq">
-                                                                <rect key="frame" x="0.0" y="79.333333333333314" width="67.666666666666671" height="26.333333333333329"/>
+                                                                <rect key="frame" x="0.0" y="79.333333333333371" width="67.666666666666671" height="26.666666666666671"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -440,7 +440,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="smY-vQ-tx3">
-                                                        <rect key="frame" x="67.666666666666657" y="0.0" width="270" height="105.66666666666667"/>
+                                                        <rect key="frame" x="67.666666666666657" y="0.0" width="270" height="106"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YsN-8l-hhp">
                                                                 <rect key="frame" x="0.0" y="0.0" width="270" height="26.666666666666668"/>
@@ -482,7 +482,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="서울 경기 새벽배송 / 전국 택배 (제주 및 도서산간 불가)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WGL-Dv-Hji">
-                                                                <rect key="frame" x="0.0" y="79.333333333333314" width="270" height="26.333333333333329"/>
+                                                                <rect key="frame" x="0.0" y="79.333333333333371" width="270" height="26.666666666666671"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <nil key="highlightedColor"/>
@@ -495,16 +495,16 @@
                                                 </constraints>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="aMr-gK-kAh" userLabel="Pre Stack View">
-                                                <rect key="frame" x="0.0" y="465.66666666666669" width="375" height="26.666666666666686"/>
+                                                <rect key="frame" x="0.0" y="532" width="375" height="26.333333333333371"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이만큼 배송됩니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R8m-qF-7RO">
-                                                        <rect key="frame" x="0.0" y="0.0" width="375" height="25.666666666666668"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="375" height="25.333333333333332"/>
                                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rMi-v9-cX1">
-                                                        <rect key="frame" x="0.0" y="25.666666666666686" width="375" height="1"/>
+                                                        <rect key="frame" x="0.0" y="25.333333333333371" width="375" height="1"/>
                                                         <color key="backgroundColor" name="divisionColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="1" id="YSt-Pp-IEt"/>
@@ -513,7 +513,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Wrf-Me-EJX" userLabel="Image Stack View">
-                                                <rect key="frame" x="0.0" y="502.33333333333337" width="375" height="0.0"/>
+                                                <rect key="frame" x="0.0" y="568.33333333333337" width="375" height="0.0"/>
                                                 <subviews>
                                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="faR-Jc-ShR" userLabel="이">
                                                         <rect key="frame" x="0.0" y="0.0" width="375" height="300"/>
@@ -542,7 +542,7 @@
                                     <constraint firstItem="Wrf-Me-EJX" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="NF2-St-gk9"/>
                                     <constraint firstItem="GzZ-zz-gCi" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" multiplier="0.95" id="UCn-pL-JXP"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="leading" secondItem="WhL-ax-RIN" secondAttribute="leading" id="X3K-Vv-8kP"/>
-                                    <constraint firstItem="pEl-4t-h4D" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.4" id="cLC-V0-cLb"/>
+                                    <constraint firstItem="pEl-4t-h4D" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.5" id="cLC-V0-cLb"/>
                                     <constraint firstItem="J91-gK-g6H" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" multiplier="0.9" id="eDR-iO-6Y8"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="trailing" secondItem="WhL-ax-RIN" secondAttribute="trailing" id="gzg-ey-xtg"/>
                                     <constraint firstItem="pEl-4t-h4D" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="iDQ-aA-BPf"/>
@@ -574,10 +574,20 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="NfB-2d-qEb"/>
                     </view>
+                    <connections>
+                        <outlet property="contentScrollView" destination="qMz-eu-sCJ" id="QWf-fj-1iP"/>
+                        <outlet property="deliveryFeeLabel" destination="WEb-tu-gWl" id="b9C-SF-N34"/>
+                        <outlet property="deliveryInfoLabel" destination="WGL-Dv-Hji" id="w5Y-G1-KVZ"/>
+                        <outlet property="descriptionLabel" destination="din-Ai-fRc" id="7In-Gi-3q7"/>
+                        <outlet property="detailImageStackView" destination="Wrf-Me-EJX" id="hvB-wC-WL3"/>
+                        <outlet property="mileageLabel" destination="GJx-wA-RDs" id="BpZ-iR-riq"/>
+                        <outlet property="thumbnailScrollView" destination="pEl-4t-h4D" id="l8V-QT-Qe5"/>
+                        <outlet property="thumbnailStackView" destination="ZVb-d1-dud" id="Zx5-iE-HxZ"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RnT-XR-7sI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2785" y="126"/>
+            <point key="canvasLocation" x="2778" y="115"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="eCI-H7-iIn">

--- a/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
+++ b/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zP7-pS-LQX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="4Oz-7T-9hJ">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -353,28 +353,20 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qMz-eu-sCJ" userLabel="Vertical Scroll View">
-                                <rect key="frame" x="0.0" y="44" width="375" height="660.66666666666674"/>
+                                <rect key="frame" x="0.0" y="44" width="375" height="660.66666666666663"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="oHd-zl-Tmv" userLabel="Content Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1702.3333333333333"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="502.33333333333331"/>
                                         <subviews>
                                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pEl-4t-h4D" userLabel="Horizontal Scroll View">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="264.33333333333331"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="ZVb-d1-dud">
-                                                        <rect key="frame" x="0.0" y="0.0" width="1125" height="264.33333333333331"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="0.0" height="264.33333333333331"/>
                                                         <subviews>
-                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FVe-LJ-ivg">
+                                                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FVe-LJ-ivg">
                                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="264.33333333333331"/>
                                                                 <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                            </view>
-                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4ZN-j4-dEZ">
-                                                                <rect key="frame" x="375" y="0.0" width="375" height="264.33333333333331"/>
-                                                                <color key="backgroundColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                            </view>
-                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8ja-qA-Xqs">
-                                                                <rect key="frame" x="750" y="0.0" width="375" height="264.33333333333331"/>
-                                                                <color key="backgroundColor" systemColor="systemIndigoColor" red="0.34509803919999998" green="0.33725490200000002" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             </view>
                                                         </subviews>
                                                     </stackView>
@@ -520,42 +512,18 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Wrf-Me-EJX" userLabel="Image Stack View">
-                                                <rect key="frame" x="0.0" y="502.33333333333348" width="375" height="1200"/>
+                                                <rect key="frame" x="0.0" y="502.33333333333337" width="375" height="0.0"/>
                                                 <subviews>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="faR-Jc-ShR" userLabel="이">
+                                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="faR-Jc-ShR" userLabel="이">
                                                         <rect key="frame" x="0.0" y="0.0" width="375" height="300"/>
                                                         <color key="backgroundColor" systemColor="systemPinkColor" red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="300" id="ogO-0B-kUe"/>
                                                         </constraints>
                                                     </view>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l4A-9G-vKo" userLabel="이">
-                                                        <rect key="frame" x="0.0" y="300" width="375" height="300"/>
-                                                        <color key="backgroundColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="300" id="YFL-Of-4fq"/>
-                                                        </constraints>
-                                                    </view>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="evf-we-rNd" userLabel="이">
-                                                        <rect key="frame" x="0.0" y="599.99999999999989" width="375" height="300"/>
-                                                        <color key="backgroundColor" systemColor="systemPinkColor" red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="300" id="6TF-uX-n6R"/>
-                                                        </constraints>
-                                                    </view>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LK6-gn-9ez" userLabel="이">
-                                                        <rect key="frame" x="0.0" y="900" width="375" height="300"/>
-                                                        <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="300" id="8LT-pE-xgy"/>
-                                                        </constraints>
-                                                    </view>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstItem="LK6-gn-9ez" firstAttribute="width" secondItem="evf-we-rNd" secondAttribute="width" id="1Ov-ym-dZS"/>
                                                     <constraint firstItem="faR-Jc-ShR" firstAttribute="width" secondItem="Wrf-Me-EJX" secondAttribute="width" id="4hF-bw-Mkx"/>
-                                                    <constraint firstItem="l4A-9G-vKo" firstAttribute="width" secondItem="faR-Jc-ShR" secondAttribute="width" id="paI-MY-iRw"/>
-                                                    <constraint firstItem="evf-we-rNd" firstAttribute="width" secondItem="l4A-9G-vKo" secondAttribute="width" id="ySF-R2-3jx"/>
                                                 </constraints>
                                             </stackView>
                                         </subviews>

--- a/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
+++ b/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
@@ -357,7 +357,7 @@
                                 <rect key="frame" x="0.0" y="44" width="375" height="660.66666666666663"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="oHd-zl-Tmv" userLabel="Content Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="555.33333333333337"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="532"/>
                                         <subviews>
                                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pEl-4t-h4D" userLabel="Horizontal Scroll View">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="330.33333333333331"/>
@@ -366,7 +366,7 @@
                                                         <rect key="frame" x="0.0" y="0.0" width="0.0" height="330.33333333333331"/>
                                                         <subviews>
                                                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FVe-LJ-ivg">
-                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="264.33333333333331"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="264.66666666666669"/>
                                                                 <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             </view>
                                                         </subviews>
@@ -400,8 +400,15 @@
                                                     </label>
                                                 </subviews>
                                             </stackView>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nw5-Xt-fKH" userLabel="Division View">
+                                                <rect key="frame" x="9.3333333333333428" y="403" width="356.33333333333326" height="3"/>
+                                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="3" id="tLo-FK-SlD"/>
+                                                </constraints>
+                                            </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="le8-v4-LtK" userLabel="Info Stack View">
-                                                <rect key="frame" x="18.666666666666657" y="403" width="337.66666666666674" height="106"/>
+                                                <rect key="frame" x="18.666666666666657" y="416" width="337.66666666666674" height="106"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="4pk-3C-dO0">
                                                         <rect key="frame" x="0.0" y="0.0" width="67.666666666666671" height="106"/>
@@ -487,26 +494,8 @@
                                                     <constraint firstItem="4pk-3C-dO0" firstAttribute="width" secondItem="le8-v4-LtK" secondAttribute="width" multiplier="0.2" id="mhz-Jc-YIb"/>
                                                 </constraints>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="aMr-gK-kAh" userLabel="Pre Stack View">
-                                                <rect key="frame" x="0.0" y="519" width="375" height="26.333333333333371"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이만큼 배송됩니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R8m-qF-7RO">
-                                                        <rect key="frame" x="0.0" y="0.0" width="375" height="25.333333333333332"/>
-                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rMi-v9-cX1">
-                                                        <rect key="frame" x="0.0" y="25.333333333333371" width="375" height="1"/>
-                                                        <color key="backgroundColor" name="divisionColor"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="1" id="YSt-Pp-IEt"/>
-                                                        </constraints>
-                                                    </view>
-                                                </subviews>
-                                            </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Wrf-Me-EJX" userLabel="Image Stack View">
-                                                <rect key="frame" x="0.0" y="555.33333333333337" width="375" height="0.0"/>
+                                                <rect key="frame" x="0.0" y="532" width="375" height="0.0"/>
                                                 <subviews>
                                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="faR-Jc-ShR" userLabel="이">
                                                         <rect key="frame" x="0.0" y="0.0" width="375" height="300"/>
@@ -529,16 +518,15 @@
                                 <constraints>
                                     <constraint firstItem="J91-gK-g6H" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.08" id="1hJ-Yd-2yB"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="bottom" secondItem="WhL-ax-RIN" secondAttribute="bottom" id="2ap-JU-kEw"/>
-                                    <constraint firstItem="aMr-gK-kAh" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.04" id="8Zb-3M-cpg"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="FXr-kX-ZcU"/>
                                     <constraint firstItem="le8-v4-LtK" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.16" id="Ggx-5M-0Eo"/>
                                     <constraint firstItem="Wrf-Me-EJX" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="NF2-St-gk9"/>
+                                    <constraint firstItem="nw5-Xt-fKH" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" multiplier="0.95" id="QYa-7i-gJl"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="leading" secondItem="WhL-ax-RIN" secondAttribute="leading" id="X3K-Vv-8kP"/>
                                     <constraint firstItem="pEl-4t-h4D" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.5" id="cLC-V0-cLb"/>
                                     <constraint firstItem="J91-gK-g6H" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" multiplier="0.9" id="eDR-iO-6Y8"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="trailing" secondItem="WhL-ax-RIN" secondAttribute="trailing" id="gzg-ey-xtg"/>
                                     <constraint firstItem="pEl-4t-h4D" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="iDQ-aA-BPf"/>
-                                    <constraint firstItem="aMr-gK-kAh" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="p2Y-QB-txc"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="top" secondItem="WhL-ax-RIN" secondAttribute="top" id="uXo-8p-QAm"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="WhL-ax-RIN"/>
@@ -575,6 +563,7 @@
                         <outlet property="mileageLabel" destination="GJx-wA-RDs" id="BpZ-iR-riq"/>
                         <outlet property="thumbnailScrollView" destination="pEl-4t-h4D" id="l8V-QT-Qe5"/>
                         <outlet property="thumbnailStackView" destination="ZVb-d1-dud" id="Zx5-iE-HxZ"/>
+                        <outlet property="titleLabel" destination="4fG-oy-fpg" id="C25-W7-ZDL"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RnT-XR-7sI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -606,9 +595,6 @@
         </namedColor>
         <namedColor name="PrimaryColor">
             <color red="0.37254901960784315" green="0.74509803921568629" blue="0.73333333333333328" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="divisionColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </namedColor>
     </resources>
 </document>

--- a/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
+++ b/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
@@ -353,10 +353,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qMz-eu-sCJ" userLabel="Vertical Scroll View">
-                                <rect key="frame" x="0.0" y="44" width="375" height="660.66666666666663"/>
+                                <rect key="frame" x="0.0" y="44" width="375" height="660.66666666666674"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="oHd-zl-Tmv" userLabel="Content Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1660.6666666666667"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="oHd-zl-Tmv" userLabel="Content Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1702.3333333333333"/>
                                         <subviews>
                                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pEl-4t-h4D" userLabel="Horizontal Scroll View">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="264.33333333333331"/>
@@ -391,7 +391,7 @@
                                                 <viewLayoutGuide key="frameLayoutGuide" id="73M-un-vdE"/>
                                             </scrollView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="J91-gK-g6H" userLabel="Title Stack View">
-                                                <rect key="frame" x="18.666666666666657" y="269.33333333333331" width="337.66666666666674" height="52.666666666666686"/>
+                                                <rect key="frame" x="18.666666666666657" y="274.33333333333331" width="337.66666666666674" height="52.666666666666686"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="[모이세] 육개장 1팩(600g)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4fG-oy-fpg" userLabel="Title Label">
                                                         <rect key="frame" x="0.0" y="0.0" width="337.66666666666669" height="28"/>
@@ -408,14 +408,14 @@
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GzZ-zz-gCi" userLabel="DivisionView">
-                                                <rect key="frame" x="9.3333333333333428" y="327" width="356.33333333333326" height="3"/>
+                                                <rect key="frame" x="9.3333333333333428" y="337" width="356.33333333333326" height="3"/>
                                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="3" id="KAf-qZ-pdK"/>
                                                 </constraints>
                                             </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="le8-v4-LtK" userLabel="Info Stack View">
-                                                <rect key="frame" x="18.666666666666657" y="335" width="337.66666666666674" height="105.66666666666669"/>
+                                                <rect key="frame" x="18.666666666666657" y="350" width="337.66666666666674" height="105.66666666666669"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="4pk-3C-dO0">
                                                         <rect key="frame" x="0.0" y="0.0" width="67.666666666666671" height="105.66666666666667"/>
@@ -452,14 +452,14 @@
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YsN-8l-hhp">
                                                                 <rect key="frame" x="0.0" y="0.0" width="270" height="26.666666666666668"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4,400원" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fNg-Si-ZWN">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="4,400원" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fNg-Si-ZWN">
                                                                         <rect key="frame" x="205" y="0.0" width="65" height="26.666666666666668"/>
                                                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                                                         <color key="textColor" name="PrimaryColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5,900원" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Ao-Yf-CIr">
-                                                                        <rect key="frame" x="153.33333333333331" y="0.0" width="46.666666666666657" height="26.666666666666668"/>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5,900원" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Ao-Yf-CIr">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="200" height="26.666666666666668"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                         <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <nil key="highlightedColor"/>
@@ -469,6 +469,7 @@
                                                                 <constraints>
                                                                     <constraint firstAttribute="bottom" secondItem="8Ao-Yf-CIr" secondAttribute="bottom" id="Eq2-cJ-V7q"/>
                                                                     <constraint firstItem="fNg-Si-ZWN" firstAttribute="top" secondItem="YsN-8l-hhp" secondAttribute="top" id="KU4-d2-wUX"/>
+                                                                    <constraint firstItem="8Ao-Yf-CIr" firstAttribute="leading" secondItem="YsN-8l-hhp" secondAttribute="leading" id="SME-o6-CjF"/>
                                                                     <constraint firstItem="8Ao-Yf-CIr" firstAttribute="top" secondItem="YsN-8l-hhp" secondAttribute="top" id="V5Q-wX-Uon"/>
                                                                     <constraint firstAttribute="trailing" secondItem="fNg-Si-ZWN" secondAttribute="trailing" id="a1a-Ih-1J5"/>
                                                                     <constraint firstItem="fNg-Si-ZWN" firstAttribute="leading" secondItem="8Ao-Yf-CIr" secondAttribute="trailing" constant="5" id="tXN-wh-bHL"/>
@@ -500,42 +501,65 @@
                                                     <constraint firstItem="4pk-3C-dO0" firstAttribute="width" secondItem="le8-v4-LtK" secondAttribute="width" multiplier="0.2" id="mhz-Jc-YIb"/>
                                                 </constraints>
                                             </stackView>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="faR-Jc-ShR" userLabel="이">
-                                                <rect key="frame" x="0.0" y="445.66666666666674" width="375" height="300"/>
-                                                <color key="backgroundColor" systemColor="systemPinkColor" red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="aMr-gK-kAh" userLabel="Pre Stack View">
+                                                <rect key="frame" x="0.0" y="465.66666666666669" width="375" height="26.666666666666686"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이만큼 배송됩니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R8m-qF-7RO">
+                                                        <rect key="frame" x="0.0" y="0.0" width="375" height="25.666666666666668"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rMi-v9-cX1">
+                                                        <rect key="frame" x="0.0" y="25.666666666666686" width="375" height="1"/>
+                                                        <color key="backgroundColor" name="divisionColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="1" id="YSt-Pp-IEt"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Wrf-Me-EJX" userLabel="Image Stack View">
+                                                <rect key="frame" x="0.0" y="502.33333333333348" width="375" height="1200"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="faR-Jc-ShR" userLabel="이">
+                                                        <rect key="frame" x="0.0" y="0.0" width="375" height="300"/>
+                                                        <color key="backgroundColor" systemColor="systemPinkColor" red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="300" id="ogO-0B-kUe"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l4A-9G-vKo" userLabel="이">
+                                                        <rect key="frame" x="0.0" y="300" width="375" height="300"/>
+                                                        <color key="backgroundColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="300" id="YFL-Of-4fq"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="evf-we-rNd" userLabel="이">
+                                                        <rect key="frame" x="0.0" y="599.99999999999989" width="375" height="300"/>
+                                                        <color key="backgroundColor" systemColor="systemPinkColor" red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="300" id="6TF-uX-n6R"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LK6-gn-9ez" userLabel="이">
+                                                        <rect key="frame" x="0.0" y="900" width="375" height="300"/>
+                                                        <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="300" id="8LT-pE-xgy"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="300" id="ogO-0B-kUe"/>
+                                                    <constraint firstItem="LK6-gn-9ez" firstAttribute="width" secondItem="evf-we-rNd" secondAttribute="width" id="1Ov-ym-dZS"/>
+                                                    <constraint firstItem="faR-Jc-ShR" firstAttribute="width" secondItem="Wrf-Me-EJX" secondAttribute="width" id="4hF-bw-Mkx"/>
+                                                    <constraint firstItem="l4A-9G-vKo" firstAttribute="width" secondItem="faR-Jc-ShR" secondAttribute="width" id="paI-MY-iRw"/>
+                                                    <constraint firstItem="evf-we-rNd" firstAttribute="width" secondItem="l4A-9G-vKo" secondAttribute="width" id="ySF-R2-3jx"/>
                                                 </constraints>
-                                            </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l4A-9G-vKo" userLabel="이">
-                                                <rect key="frame" x="0.0" y="750.66666666666663" width="375" height="299.99999999999989"/>
-                                                <color key="backgroundColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="300" id="YFL-Of-4fq"/>
-                                                </constraints>
-                                            </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="evf-we-rNd" userLabel="이">
-                                                <rect key="frame" x="0.0" y="1055.6666666666667" width="375" height="300"/>
-                                                <color key="backgroundColor" systemColor="systemPinkColor" red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="300" id="6TF-uX-n6R"/>
-                                                </constraints>
-                                            </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LK6-gn-9ez" userLabel="이">
-                                                <rect key="frame" x="0.0" y="1360.6666666666667" width="375" height="300"/>
-                                                <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="300" id="8LT-pE-xgy"/>
-                                                </constraints>
-                                            </view>
+                                            </stackView>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstItem="LK6-gn-9ez" firstAttribute="width" secondItem="evf-we-rNd" secondAttribute="width" id="4fC-N1-C5s"/>
-                                            <constraint firstItem="evf-we-rNd" firstAttribute="height" secondItem="l4A-9G-vKo" secondAttribute="height" id="Jed-qe-iYx"/>
-                                            <constraint firstItem="LK6-gn-9ez" firstAttribute="height" secondItem="evf-we-rNd" secondAttribute="height" id="TVx-KF-Wgd"/>
-                                            <constraint firstItem="l4A-9G-vKo" firstAttribute="height" secondItem="faR-Jc-ShR" secondAttribute="height" id="asu-Yj-Za1"/>
-                                            <constraint firstItem="l4A-9G-vKo" firstAttribute="width" secondItem="faR-Jc-ShR" secondAttribute="width" id="cTd-Zy-eCy"/>
-                                            <constraint firstItem="evf-we-rNd" firstAttribute="width" secondItem="l4A-9G-vKo" secondAttribute="width" id="sKq-1Q-QMA"/>
                                             <constraint firstItem="le8-v4-LtK" firstAttribute="width" secondItem="J91-gK-g6H" secondAttribute="width" id="ss8-Dp-Z72"/>
                                         </constraints>
                                     </stackView>
@@ -543,15 +567,17 @@
                                 <constraints>
                                     <constraint firstItem="J91-gK-g6H" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.08" id="1hJ-Yd-2yB"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="bottom" secondItem="WhL-ax-RIN" secondAttribute="bottom" id="2ap-JU-kEw"/>
+                                    <constraint firstItem="aMr-gK-kAh" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.04" id="8Zb-3M-cpg"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="FXr-kX-ZcU"/>
                                     <constraint firstItem="le8-v4-LtK" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.16" id="Ggx-5M-0Eo"/>
-                                    <constraint firstItem="faR-Jc-ShR" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="QNP-qP-gvQ"/>
+                                    <constraint firstItem="Wrf-Me-EJX" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="NF2-St-gk9"/>
                                     <constraint firstItem="GzZ-zz-gCi" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" multiplier="0.95" id="UCn-pL-JXP"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="leading" secondItem="WhL-ax-RIN" secondAttribute="leading" id="X3K-Vv-8kP"/>
                                     <constraint firstItem="pEl-4t-h4D" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.4" id="cLC-V0-cLb"/>
                                     <constraint firstItem="J91-gK-g6H" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" multiplier="0.9" id="eDR-iO-6Y8"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="trailing" secondItem="WhL-ax-RIN" secondAttribute="trailing" id="gzg-ey-xtg"/>
                                     <constraint firstItem="pEl-4t-h4D" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="iDQ-aA-BPf"/>
+                                    <constraint firstItem="aMr-gK-kAh" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="p2Y-QB-txc"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="top" secondItem="WhL-ax-RIN" secondAttribute="top" id="uXo-8p-QAm"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="WhL-ax-RIN"/>
@@ -609,6 +635,9 @@
         </namedColor>
         <namedColor name="PrimaryColor">
             <color red="0.37254901960784315" green="0.74509803921568629" blue="0.73333333333333328" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="divisionColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </namedColor>
     </resources>
 </document>

--- a/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
+++ b/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="4Oz-7T-9hJ">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -114,6 +114,7 @@
                                         </state>
                                         <connections>
                                             <action selector="loginButtonPushed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UJZ-hf-ZI5"/>
+                                            <segue destination="4Oz-7T-9hJ" kind="presentation" modalPresentationStyle="fullScreen" id="g6t-2V-Y4x"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -201,7 +202,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1702" y="-537"/>
+            <point key="canvasLocation" x="446" y="115"/>
         </scene>
         <!--Main Menu View Controller-->
         <scene sceneID="35g-EQ-BHf">
@@ -342,7 +343,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="n8N-sQ-S2A" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1702" y="126"/>
+            <point key="canvasLocation" x="2105" y="126"/>
         </scene>
         <!--Detail View Controller-->
         <scene sceneID="ICD-Kh-mga">
@@ -576,7 +577,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RnT-XR-7sI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2525.5999999999999" y="125.61576354679804"/>
+            <point key="canvasLocation" x="2785" y="126"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="eCI-H7-iIn">
@@ -588,12 +589,12 @@
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
-                        <segue destination="qPn-pl-vDW" kind="relationship" relationship="rootViewController" id="Vzu-Rs-HsL"/>
+                        <segue destination="qPn-pl-vDW" kind="relationship" relationship="rootViewController" id="LLh-hg-ylB"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Dh5-ht-ibj" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="884" y="125.61576354679804"/>
+            <point key="canvasLocation" x="1226" y="115"/>
         </scene>
     </scenes>
     <resources>

--- a/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
+++ b/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
@@ -351,13 +351,172 @@
                     <view key="view" contentMode="scaleToFill" id="9w0-Ty-qEz">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qMz-eu-sCJ" userLabel="Vertical Scroll View">
+                                <rect key="frame" x="0.0" y="44" width="375" height="660.66666666666663"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="oHd-zl-Tmv" userLabel="Content Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1728.3333333333333"/>
+                                        <subviews>
+                                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pEl-4t-h4D" userLabel="Horizontal Scroll View">
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="264.33333333333331"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="ZVb-d1-dud">
+                                                        <rect key="frame" x="0.0" y="0.0" width="1125" height="264.33333333333331"/>
+                                                        <subviews>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FVe-LJ-ivg">
+                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="264.33333333333331"/>
+                                                                <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            </view>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4ZN-j4-dEZ">
+                                                                <rect key="frame" x="375" y="0.0" width="375" height="264.33333333333331"/>
+                                                                <color key="backgroundColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            </view>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8ja-qA-Xqs">
+                                                                <rect key="frame" x="750" y="0.0" width="375" height="264.33333333333331"/>
+                                                                <color key="backgroundColor" systemColor="systemIndigoColor" red="0.34509803919999998" green="0.33725490200000002" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            </view>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="FVe-LJ-ivg" firstAttribute="width" secondItem="73M-un-vdE" secondAttribute="width" id="Bcw-hd-JFA"/>
+                                                    <constraint firstItem="ZVb-d1-dud" firstAttribute="bottom" secondItem="obB-fb-ydH" secondAttribute="bottom" id="JkQ-WT-DHG"/>
+                                                    <constraint firstItem="ZVb-d1-dud" firstAttribute="top" secondItem="obB-fb-ydH" secondAttribute="top" id="Ntu-gr-0lf"/>
+                                                    <constraint firstItem="ZVb-d1-dud" firstAttribute="trailing" secondItem="obB-fb-ydH" secondAttribute="trailing" id="OLF-Jr-MXv"/>
+                                                    <constraint firstItem="ZVb-d1-dud" firstAttribute="leading" secondItem="obB-fb-ydH" secondAttribute="leading" id="Y7S-5Q-DEY"/>
+                                                    <constraint firstItem="ZVb-d1-dud" firstAttribute="height" secondItem="73M-un-vdE" secondAttribute="height" id="l7S-Ck-e57"/>
+                                                </constraints>
+                                                <viewLayoutGuide key="contentLayoutGuide" id="obB-fb-ydH"/>
+                                                <viewLayoutGuide key="frameLayoutGuide" id="73M-un-vdE"/>
+                                            </scrollView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="HcK-cx-E4s" userLabel="Info Stack View">
+                                                <rect key="frame" x="18.666666666666657" y="264.33333333333331" width="337.66666666666674" height="263.99999999999994"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y4X-ll-Uf9">
+                                                        <rect key="frame" x="0.0" y="0.0" width="337.66666666666669" height="37.666666666666664"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gPf-nP-QQE">
+                                                        <rect key="frame" x="0.0" y="37.666666666666686" width="337.66666666666669" height="37.666666666666657"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tc1-tc-P8b">
+                                                        <rect key="frame" x="0.0" y="75.333333333333371" width="337.66666666666669" height="37.666666666666657"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JWl-wH-NRC">
+                                                        <rect key="frame" x="0.0" y="113" width="337.66666666666669" height="38"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nw9-98-lF9">
+                                                        <rect key="frame" x="0.0" y="151" width="337.66666666666669" height="37.666666666666657"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="13s-23-lib">
+                                                        <rect key="frame" x="0.0" y="188.66666666666669" width="337.66666666666669" height="37.666666666666657"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vO9-iO-Nhp">
+                                                        <rect key="frame" x="0.0" y="226.33333333333331" width="337.66666666666669" height="37.666666666666686"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="faR-Jc-ShR" userLabel="이">
+                                                <rect key="frame" x="0.0" y="528.33333333333337" width="375" height="300"/>
+                                                <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="300" id="ogO-0B-kUe"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l4A-9G-vKo" userLabel="이">
+                                                <rect key="frame" x="0.0" y="828.33333333333337" width="375" height="300.00000000000011"/>
+                                                <color key="backgroundColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="300" id="YFL-Of-4fq"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="evf-we-rNd" userLabel="이">
+                                                <rect key="frame" x="0.0" y="1128.3333333333333" width="375" height="300"/>
+                                                <color key="backgroundColor" systemColor="systemPinkColor" red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="300" id="6TF-uX-n6R"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LK6-gn-9ez" userLabel="이">
+                                                <rect key="frame" x="0.0" y="1428.3333333333333" width="375" height="300"/>
+                                                <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="300" id="8LT-pE-xgy"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="LK6-gn-9ez" firstAttribute="width" secondItem="evf-we-rNd" secondAttribute="width" id="4fC-N1-C5s"/>
+                                            <constraint firstItem="evf-we-rNd" firstAttribute="height" secondItem="l4A-9G-vKo" secondAttribute="height" id="Jed-qe-iYx"/>
+                                            <constraint firstItem="LK6-gn-9ez" firstAttribute="height" secondItem="evf-we-rNd" secondAttribute="height" id="TVx-KF-Wgd"/>
+                                            <constraint firstItem="l4A-9G-vKo" firstAttribute="height" secondItem="faR-Jc-ShR" secondAttribute="height" id="asu-Yj-Za1"/>
+                                            <constraint firstItem="l4A-9G-vKo" firstAttribute="width" secondItem="faR-Jc-ShR" secondAttribute="width" id="cTd-Zy-eCy"/>
+                                            <constraint firstItem="evf-we-rNd" firstAttribute="width" secondItem="l4A-9G-vKo" secondAttribute="width" id="sKq-1Q-QMA"/>
+                                        </constraints>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="oHd-zl-Tmv" firstAttribute="bottom" secondItem="WhL-ax-RIN" secondAttribute="bottom" id="2ap-JU-kEw"/>
+                                    <constraint firstItem="oHd-zl-Tmv" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="FXr-kX-ZcU"/>
+                                    <constraint firstItem="faR-Jc-ShR" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="QNP-qP-gvQ"/>
+                                    <constraint firstItem="HcK-cx-E4s" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.4" id="UhT-yp-kFo"/>
+                                    <constraint firstItem="oHd-zl-Tmv" firstAttribute="leading" secondItem="WhL-ax-RIN" secondAttribute="leading" id="X3K-Vv-8kP"/>
+                                    <constraint firstItem="pEl-4t-h4D" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.4" id="cLC-V0-cLb"/>
+                                    <constraint firstItem="oHd-zl-Tmv" firstAttribute="trailing" secondItem="WhL-ax-RIN" secondAttribute="trailing" id="gzg-ey-xtg"/>
+                                    <constraint firstItem="pEl-4t-h4D" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="iDQ-aA-BPf"/>
+                                    <constraint firstItem="HcK-cx-E4s" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" multiplier="0.9" id="sds-oC-cPC"/>
+                                    <constraint firstItem="oHd-zl-Tmv" firstAttribute="top" secondItem="WhL-ax-RIN" secondAttribute="top" id="uXo-8p-QAm"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="WhL-ax-RIN"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="ivL-gb-VLH"/>
+                            </scrollView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bsL-86-OW3">
+                                <rect key="frame" x="0.0" y="704.66666666666663" width="375" height="73.333333333333371"/>
+                                <color key="backgroundColor" name="PrimaryColor"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                <state key="normal" title="주문하기">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                            </button>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="NfB-2d-qEb" firstAttribute="trailing" secondItem="bsL-86-OW3" secondAttribute="trailing" id="2Nt-MR-7s2"/>
+                            <constraint firstItem="NfB-2d-qEb" firstAttribute="bottom" secondItem="bsL-86-OW3" secondAttribute="bottom" id="5SZ-Ln-ZDf"/>
+                            <constraint firstItem="qMz-eu-sCJ" firstAttribute="top" secondItem="NfB-2d-qEb" secondAttribute="top" id="6PU-Su-B7u"/>
+                            <constraint firstItem="qMz-eu-sCJ" firstAttribute="trailing" secondItem="NfB-2d-qEb" secondAttribute="trailing" id="DPv-cA-0dI"/>
+                            <constraint firstItem="bsL-86-OW3" firstAttribute="top" secondItem="qMz-eu-sCJ" secondAttribute="bottom" id="EY6-YD-Yas"/>
+                            <constraint firstItem="qMz-eu-sCJ" firstAttribute="leading" secondItem="NfB-2d-qEb" secondAttribute="leading" id="Ljl-ay-fuv"/>
+                            <constraint firstItem="qMz-eu-sCJ" firstAttribute="height" secondItem="NfB-2d-qEb" secondAttribute="height" multiplier="0.9" id="e9H-Bi-LI9"/>
+                            <constraint firstItem="bsL-86-OW3" firstAttribute="leading" secondItem="NfB-2d-qEb" secondAttribute="leading" id="oKm-4K-jeF"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="NfB-2d-qEb"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="RnT-XR-7sI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2527" y="126"/>
+            <point key="canvasLocation" x="2525.5999999999999" y="125.61576354679804"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="eCI-H7-iIn">

--- a/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
+++ b/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
@@ -357,7 +357,7 @@
                                 <rect key="frame" x="0.0" y="44" width="375" height="660.66666666666663"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="oHd-zl-Tmv" userLabel="Content Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="568.33333333333337"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="555.33333333333337"/>
                                         <subviews>
                                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pEl-4t-h4D" userLabel="Horizontal Scroll View">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="330.33333333333331"/>
@@ -400,15 +400,8 @@
                                                     </label>
                                                 </subviews>
                                             </stackView>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GzZ-zz-gCi" userLabel="DivisionView">
-                                                <rect key="frame" x="9.3333333333333428" y="403" width="356.33333333333326" height="3"/>
-                                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="3" id="KAf-qZ-pdK"/>
-                                                </constraints>
-                                            </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="le8-v4-LtK" userLabel="Info Stack View">
-                                                <rect key="frame" x="18.666666666666657" y="416" width="337.66666666666674" height="106"/>
+                                                <rect key="frame" x="18.666666666666657" y="403" width="337.66666666666674" height="106"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="4pk-3C-dO0">
                                                         <rect key="frame" x="0.0" y="0.0" width="67.666666666666671" height="106"/>
@@ -495,7 +488,7 @@
                                                 </constraints>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="aMr-gK-kAh" userLabel="Pre Stack View">
-                                                <rect key="frame" x="0.0" y="532" width="375" height="26.333333333333371"/>
+                                                <rect key="frame" x="0.0" y="519" width="375" height="26.333333333333371"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이만큼 배송됩니다." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R8m-qF-7RO">
                                                         <rect key="frame" x="0.0" y="0.0" width="375" height="25.333333333333332"/>
@@ -513,7 +506,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Wrf-Me-EJX" userLabel="Image Stack View">
-                                                <rect key="frame" x="0.0" y="568.33333333333337" width="375" height="0.0"/>
+                                                <rect key="frame" x="0.0" y="555.33333333333337" width="375" height="0.0"/>
                                                 <subviews>
                                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="faR-Jc-ShR" userLabel="이">
                                                         <rect key="frame" x="0.0" y="0.0" width="375" height="300"/>
@@ -540,7 +533,6 @@
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="FXr-kX-ZcU"/>
                                     <constraint firstItem="le8-v4-LtK" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.16" id="Ggx-5M-0Eo"/>
                                     <constraint firstItem="Wrf-Me-EJX" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="NF2-St-gk9"/>
-                                    <constraint firstItem="GzZ-zz-gCi" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" multiplier="0.95" id="UCn-pL-JXP"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="leading" secondItem="WhL-ax-RIN" secondAttribute="leading" id="X3K-Vv-8kP"/>
                                     <constraint firstItem="pEl-4t-h4D" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.5" id="cLC-V0-cLb"/>
                                     <constraint firstItem="J91-gK-g6H" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" multiplier="0.9" id="eDR-iO-6Y8"/>

--- a/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
+++ b/iOS/SideDish/SideDish/StoryBoard/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="4Oz-7T-9hJ">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zP7-pS-LQX">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -355,8 +355,8 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qMz-eu-sCJ" userLabel="Vertical Scroll View">
                                 <rect key="frame" x="0.0" y="44" width="375" height="660.66666666666663"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="oHd-zl-Tmv" userLabel="Content Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1728.3333333333333"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="oHd-zl-Tmv" userLabel="Content Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1660.6666666666667"/>
                                         <subviews>
                                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pEl-4t-h4D" userLabel="Horizontal Scroll View">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="264.33333333333331"/>
@@ -390,76 +390,139 @@
                                                 <viewLayoutGuide key="contentLayoutGuide" id="obB-fb-ydH"/>
                                                 <viewLayoutGuide key="frameLayoutGuide" id="73M-un-vdE"/>
                                             </scrollView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="HcK-cx-E4s" userLabel="Info Stack View">
-                                                <rect key="frame" x="18.666666666666657" y="264.33333333333331" width="337.66666666666674" height="263.99999999999994"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="J91-gK-g6H" userLabel="Title Stack View">
+                                                <rect key="frame" x="18.666666666666657" y="269.33333333333331" width="337.66666666666674" height="52.666666666666686"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y4X-ll-Uf9">
-                                                        <rect key="frame" x="0.0" y="0.0" width="337.66666666666669" height="37.666666666666664"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="[모이세] 육개장 1팩(600g)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4fG-oy-fpg" userLabel="Title Label">
+                                                        <rect key="frame" x="0.0" y="0.0" width="337.66666666666669" height="28"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gPf-nP-QQE">
-                                                        <rect key="frame" x="0.0" y="37.666666666666686" width="337.66666666666669" height="37.666666666666657"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tc1-tc-P8b">
-                                                        <rect key="frame" x="0.0" y="75.333333333333371" width="337.66666666666669" height="37.666666666666657"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JWl-wH-NRC">
-                                                        <rect key="frame" x="0.0" y="113" width="337.66666666666669" height="38"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nw9-98-lF9">
-                                                        <rect key="frame" x="0.0" y="151" width="337.66666666666669" height="37.666666666666657"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="13s-23-lib">
-                                                        <rect key="frame" x="0.0" y="188.66666666666669" width="337.66666666666669" height="37.666666666666657"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vO9-iO-Nhp">
-                                                        <rect key="frame" x="0.0" y="226.33333333333331" width="337.66666666666669" height="37.666666666666686"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제주 3대해장국 맛집의 인기메뉴" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="din-Ai-fRc" userLabel="SubTitle Label">
+                                                        <rect key="frame" x="0.0" y="28" width="337.66666666666669" height="24.666666666666671"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GzZ-zz-gCi" userLabel="DivisionView">
+                                                <rect key="frame" x="9.3333333333333428" y="327" width="356.33333333333326" height="3"/>
+                                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="3" id="KAf-qZ-pdK"/>
+                                                </constraints>
+                                            </view>
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="le8-v4-LtK" userLabel="Info Stack View">
+                                                <rect key="frame" x="18.666666666666657" y="335" width="337.66666666666674" height="105.66666666666669"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="4pk-3C-dO0">
+                                                        <rect key="frame" x="0.0" y="0.0" width="67.666666666666671" height="105.66666666666667"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="가격" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DNG-bo-bmG">
+                                                                <rect key="frame" x="0.0" y="0.0" width="67.666666666666671" height="26.666666666666668"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="적립금" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R31-Sr-g4z">
+                                                                <rect key="frame" x="0.0" y="26.666666666666686" width="67.666666666666671" height="26.333333333333329"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="배송비" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PFP-i7-Oa7">
+                                                                <rect key="frame" x="0.0" y="53.000000000000007" width="67.666666666666671" height="26.333333333333336"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="배송정보" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tue-fG-Jdq">
+                                                                <rect key="frame" x="0.0" y="79.333333333333314" width="67.666666666666671" height="26.333333333333329"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="smY-vQ-tx3">
+                                                        <rect key="frame" x="67.666666666666657" y="0.0" width="270" height="105.66666666666667"/>
+                                                        <subviews>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YsN-8l-hhp">
+                                                                <rect key="frame" x="0.0" y="0.0" width="270" height="26.666666666666668"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4,400원" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fNg-Si-ZWN">
+                                                                        <rect key="frame" x="205" y="0.0" width="65" height="26.666666666666668"/>
+                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                                        <color key="textColor" name="PrimaryColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="5,900원" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Ao-Yf-CIr">
+                                                                        <rect key="frame" x="153.33333333333331" y="0.0" width="46.666666666666657" height="26.666666666666668"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                                        <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="bottom" secondItem="8Ao-Yf-CIr" secondAttribute="bottom" id="Eq2-cJ-V7q"/>
+                                                                    <constraint firstItem="fNg-Si-ZWN" firstAttribute="top" secondItem="YsN-8l-hhp" secondAttribute="top" id="KU4-d2-wUX"/>
+                                                                    <constraint firstItem="8Ao-Yf-CIr" firstAttribute="top" secondItem="YsN-8l-hhp" secondAttribute="top" id="V5Q-wX-Uon"/>
+                                                                    <constraint firstAttribute="trailing" secondItem="fNg-Si-ZWN" secondAttribute="trailing" id="a1a-Ih-1J5"/>
+                                                                    <constraint firstItem="fNg-Si-ZWN" firstAttribute="leading" secondItem="8Ao-Yf-CIr" secondAttribute="trailing" constant="5" id="tXN-wh-bHL"/>
+                                                                    <constraint firstAttribute="bottom" secondItem="fNg-Si-ZWN" secondAttribute="bottom" id="vc0-QW-Yeo"/>
+                                                                </constraints>
+                                                            </view>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="44원" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GJx-wA-RDs">
+                                                                <rect key="frame" x="0.0" y="26.666666666666686" width="270" height="26.333333333333329"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2,500원 (40,000원 이상 구매 시 무료)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WEb-tu-gWl">
+                                                                <rect key="frame" x="0.0" y="53.000000000000007" width="270" height="26.333333333333336"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="서울 경기 새벽배송 / 전국 택배 (제주 및 도서산간 불가)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WGL-Dv-Hji">
+                                                                <rect key="frame" x="0.0" y="79.333333333333314" width="270" height="26.333333333333329"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="4pk-3C-dO0" firstAttribute="width" secondItem="le8-v4-LtK" secondAttribute="width" multiplier="0.2" id="mhz-Jc-YIb"/>
+                                                </constraints>
+                                            </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="faR-Jc-ShR" userLabel="이">
-                                                <rect key="frame" x="0.0" y="528.33333333333337" width="375" height="300"/>
-                                                <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <rect key="frame" x="0.0" y="445.66666666666674" width="375" height="300"/>
+                                                <color key="backgroundColor" systemColor="systemPinkColor" red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="300" id="ogO-0B-kUe"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l4A-9G-vKo" userLabel="이">
-                                                <rect key="frame" x="0.0" y="828.33333333333337" width="375" height="300.00000000000011"/>
+                                                <rect key="frame" x="0.0" y="750.66666666666663" width="375" height="299.99999999999989"/>
                                                 <color key="backgroundColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="300" id="YFL-Of-4fq"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="evf-we-rNd" userLabel="이">
-                                                <rect key="frame" x="0.0" y="1128.3333333333333" width="375" height="300"/>
+                                                <rect key="frame" x="0.0" y="1055.6666666666667" width="375" height="300"/>
                                                 <color key="backgroundColor" systemColor="systemPinkColor" red="1" green="0.1764705882" blue="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="300" id="6TF-uX-n6R"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LK6-gn-9ez" userLabel="이">
-                                                <rect key="frame" x="0.0" y="1428.3333333333333" width="375" height="300"/>
+                                                <rect key="frame" x="0.0" y="1360.6666666666667" width="375" height="300"/>
                                                 <color key="backgroundColor" systemColor="systemYellowColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="300" id="8LT-pE-xgy"/>
@@ -473,19 +536,22 @@
                                             <constraint firstItem="l4A-9G-vKo" firstAttribute="height" secondItem="faR-Jc-ShR" secondAttribute="height" id="asu-Yj-Za1"/>
                                             <constraint firstItem="l4A-9G-vKo" firstAttribute="width" secondItem="faR-Jc-ShR" secondAttribute="width" id="cTd-Zy-eCy"/>
                                             <constraint firstItem="evf-we-rNd" firstAttribute="width" secondItem="l4A-9G-vKo" secondAttribute="width" id="sKq-1Q-QMA"/>
+                                            <constraint firstItem="le8-v4-LtK" firstAttribute="width" secondItem="J91-gK-g6H" secondAttribute="width" id="ss8-Dp-Z72"/>
                                         </constraints>
                                     </stackView>
                                 </subviews>
                                 <constraints>
+                                    <constraint firstItem="J91-gK-g6H" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.08" id="1hJ-Yd-2yB"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="bottom" secondItem="WhL-ax-RIN" secondAttribute="bottom" id="2ap-JU-kEw"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="FXr-kX-ZcU"/>
+                                    <constraint firstItem="le8-v4-LtK" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.16" id="Ggx-5M-0Eo"/>
                                     <constraint firstItem="faR-Jc-ShR" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="QNP-qP-gvQ"/>
-                                    <constraint firstItem="HcK-cx-E4s" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.4" id="UhT-yp-kFo"/>
+                                    <constraint firstItem="GzZ-zz-gCi" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" multiplier="0.95" id="UCn-pL-JXP"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="leading" secondItem="WhL-ax-RIN" secondAttribute="leading" id="X3K-Vv-8kP"/>
                                     <constraint firstItem="pEl-4t-h4D" firstAttribute="height" secondItem="ivL-gb-VLH" secondAttribute="height" multiplier="0.4" id="cLC-V0-cLb"/>
+                                    <constraint firstItem="J91-gK-g6H" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" multiplier="0.9" id="eDR-iO-6Y8"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="trailing" secondItem="WhL-ax-RIN" secondAttribute="trailing" id="gzg-ey-xtg"/>
                                     <constraint firstItem="pEl-4t-h4D" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" id="iDQ-aA-BPf"/>
-                                    <constraint firstItem="HcK-cx-E4s" firstAttribute="width" secondItem="ivL-gb-VLH" secondAttribute="width" multiplier="0.9" id="sds-oC-cPC"/>
                                     <constraint firstItem="oHd-zl-Tmv" firstAttribute="top" secondItem="WhL-ax-RIN" secondAttribute="top" id="uXo-8p-QAm"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="WhL-ax-RIN"/>


### PR DESCRIPTION
### 서버 통신 부분

상세화면에 필요한 모델을 구분하기 위해 `MainMenuViewController`가 `DetailViewController`에게 ID를 주입해줬습니다.

주입 받은 ID를 이용하여 `DetailViewController` 가 appear 되기 전에(`viewWillAppear(_ animaited: Bool`) 서버에 모델을 요청 했습니다. 모델이 변하면 모델을 저장하는 프로퍼티에 didSet을 설정해서 UI를 변경했습니다.

image를 받아오는 경우는 downloadTask를 활용하여 로컬 디렉토리에 저장하고, caches 디렉토리로 옮겨줬습니다. 후에 동일한 이미지를 요청하는 경우는 네트워크 요청을 하지 않고 로컬 URL에서 데이터를 불러옵니다.

주문하기 버튼의 경우 서버에서 api 작성이 완료되면 처리하겠습니다.

### UI 부분

스크롤뷰를 사용해서 많은 양의 콘텐츠를 스크롤해서 볼 수 있도록 UI를 구성했습니다. 

스크롤뷰 내에 컨텐츠를 비워두면 오토레이아웃 경고가 발생해서 각 스크롤뷰에 dummy view를 하나씩 넣어주고 hidden 처리를 해서 오토레이아웃 경고를 없앴습니다.

Content Layout Guide와 Frame Layout Guide의 차이를 공부 했습니다. Content Layout Guide는 스크롤 뷰에 표시될 컨텐츠와 관련이 있고, Frame Layout Guide는 스크롤 뷰 자체의 크기와 관련 있습니다.

paging을 사용해서 이미지를 한장한장 넘길 수 있도록 했습니다.

image를 비동기로 처리하기 때문에 image의 순서를 맞춰주기 위해 스택뷰에 먼저 UIImageView를 넣어주고, 해당 ImageView에 비동기로 도착한 image를 넣어줬습니다.